### PR TITLE
Vehicle not able to be driven by requesting player

### DIFF
--- a/source/support/spawn_vehicle.sqf
+++ b/source/support/spawn_vehicle.sqf
@@ -23,9 +23,8 @@ if (commandpointsblu1 >= _cost) then {
     hint "Vehicle ready! check map for location";
     commandpointsblu1 = commandpointsblu1 - _cost;
     ctrlSetText [MENU_COMMAND_POINTS_BLU, format["%1",commandpointsblu1]];
-    //spawning the vehicle in 0.0.0 then moving it is faster than spawning it in a specific location.
-    _vehic = _name createVehicle [0,0,0];
-    _vehic setPos (_pos);
+    //Spawn the Vehicle in
+    _vehic = _name createVehicle _pos;
     //create a marker for the new vehicle
     [_pos] spawn _spawn_marker;
 } else {


### PR DESCRIPTION
Fixes an intermittent issue where a player that requests a vehicle can't
drive it.

This appears to be an issue with spawning at [0,0,0] and then using a
setPos to the desired location (as per Bohemia's code optimisation).

@amanuense - I've had another look at this with another round of testing and the issue is still there without this 'fix', so I'd like to merge this and crack on with some other bugsquashing. If you're ok with this, approve the merge and i'll move on to other bugs, if i find them.

Thanks,
Cai